### PR TITLE
Update only nokogiri gem version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -90,11 +90,11 @@ GEM
       rb-inotify (>= 0.9)
     maruku (0.7.0)
     mercenary (0.3.5)
-    mini_portile (0.6.1)
+    mini_portile2 (2.4.0)
     minitest (5.4.3)
     net-dns (0.8.0)
-    nokogiri (1.6.4.1)
-      mini_portile (~> 0.6.0)
+    nokogiri (1.10.4)
+      mini_portile2 (~> 2.4.0)
     parslet (1.5.0)
       blankslate (~> 2.0)
     posix-spawn (0.3.9)
@@ -126,4 +126,4 @@ DEPENDENCIES
   github-pages
 
 BUNDLED WITH
-   1.14.3
+   1.17.3


### PR DESCRIPTION
This fixes the web Nokogiri version without updating the whole Gemfile (Which upgrades jekyll version and brings a lot of new issues)